### PR TITLE
metrics name should be not dynamic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 export GOBIN := $(PWD)/bin
 export PATH := $(GOBIN):$(PATH)
 export INSTALL_FLAG=
-export TAG=0.3.0
+export TAG=0.4.0
 
 DOCKER_IMAGE = aws-limits-exporter
-DOCKER_REPO = danielfm
+DOCKER_REPO = gcr.io/pingcap-public
 
 # Determine which OS.
 OS?=$(shell uname -s | tr A-Z a-z)

--- a/core/support.go
+++ b/core/support.go
@@ -296,7 +296,7 @@ func (e *SupportExporter) Collect(ch chan<- prometheus.Metric) {
 
 func newServerMetric(region, subSystem, metricName, docString string, labels []string) *prometheus.Desc {
 	return prometheus.NewDesc(
-		prometheus.BuildFQName("aws", subSystem, metricName),
+		prometheus.BuildFQName("aws", "quota", metricName),
 		docString, labels, prometheus.Labels{"region": region},
 	)
 }


### PR DESCRIPTION
1. resource info already in the metrics label, just use `aws_quota_used_total` as metrics name. this  would be helpful when add grafana dashboards and alerts